### PR TITLE
Fix Twitter auth invalid request token error

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -689,7 +689,8 @@ export const useAuthStore = defineStore('auth', {
       await this.cancelTwitterAuth()
 
       try {
-        let url = `${this.backendUrl}/auth/twitter`
+        // Add cache-busting param to prevent in-app browsers from caching the OAuth redirect
+        let url = `${this.backendUrl}/auth/twitter?_t=${Date.now()}`
         if (this.isAuthenticated) {
           // authenticated users need a nonce to connect the accounts
           const nonceResponse = await fetch(`${this.backendUrl}/auth/twitter-nonce`, {
@@ -705,7 +706,7 @@ export const useAuthStore = defineStore('auth', {
           }
 
           const { nonce } = await nonceResponse.json()
-          url += `?nonce=${encodeURIComponent(nonce)}`
+          url += `&nonce=${encodeURIComponent(nonce)}`
         }
 
         if (this.isFarcaster) {


### PR DESCRIPTION
## Summary
- Adds a cache-busting `_t` timestamp parameter to the `/auth/twitter` URL on the client side
- Fixes nonce parameter to use `&` instead of `?` since the cache-busting param is now first
- Prevents in-app browsers (especially Farcaster) from serving a cached OAuth redirect with a stale `oauth_token`

## Context
Users were seeing Twitter's "Whoa there! The request token for this page is invalid" error when trying to connect Twitter, particularly from Farcaster mini-apps. The root cause is that in-app browsers can cache the 302 redirect from `/auth/twitter` which contains the `oauth_token` — reusing a stale token causes Twitter to reject it.

Companion PR: trifle-labs/trifle-bot (server-side cache-control headers)

## Test plan
- [ ] Test Twitter auth flow from Farcaster mini-app (previously broken)
- [ ] Test Twitter auth flow from desktop browser (should still work)
- [ ] Test connecting Twitter as both new user and existing authenticated user

🤖 Generated with [Claude Code](https://claude.com/claude-code)