### PR TITLE
Fix auth flow in Twitter/X in-app browser

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -260,6 +260,24 @@ export const useAuthStore = defineStore('auth', {
           console.warn('error initializing farcaster', e)
         }
 
+        // Check for auth token in URL hash (redirect fallback from in-app browsers
+        // where window.opener.postMessage doesn't work, e.g. Twitter/X in-app browser)
+        const hash = window.location.hash
+        if (hash.includes('trifle_auth_token=')) {
+          const hashParams = new URLSearchParams(hash.substring(1))
+          const hashToken = hashParams.get('trifle_auth_token')
+          if (hashToken) {
+            this.setAuthToken(hashToken)
+            // Clean the token from the URL immediately
+            window.history.replaceState(null, '', window.location.pathname + window.location.search)
+            try {
+              await this.fetchUserStatus()
+            } catch (e) {
+              console.warn('Failed to fetch user status from redirect token:', e.message)
+            }
+          }
+        }
+
         const token = localStorage.getItem('authToken')
         if (token) {
           this.setAuthToken(token)
@@ -525,7 +543,7 @@ export const useAuthStore = defineStore('auth', {
 
       try {
         // const hasDiscordAuth = this.user?.linkedAccounts?.discord?.length > 0
-        let url = `${this.backendUrl}/auth/discord`
+        let url = `${this.backendUrl}/auth/discord?origin=${encodeURIComponent(window.location.href)}`
         if (this.isAuthenticated) {
           // For additional auth, get a nonce first
           const nonceResponse = await fetch(`${this.backendUrl}/auth/discord-nonce`, {
@@ -714,7 +732,9 @@ export const useAuthStore = defineStore('auth', {
 
       try {
         // Add cache-busting param to prevent in-app browsers from caching the OAuth redirect
-        let url = `${this.backendUrl}/auth/twitter?_t=${Date.now()}`
+        // Pass origin so the backend can redirect back here if window.opener is unavailable
+        // (e.g. Twitter/X in-app browser where postMessage doesn't work)
+        let url = `${this.backendUrl}/auth/twitter?_t=${Date.now()}&origin=${encodeURIComponent(window.location.href)}`
         if (this.isAuthenticated) {
           // authenticated users need a nonce to connect the accounts
           const nonceResponse = await fetch(`${this.backendUrl}/auth/twitter-nonce`, {


### PR DESCRIPTION
## Summary
- Passes `origin` (current page URL) to `/auth/twitter` and `/auth/discord` so the backend can redirect back when `window.opener` is unavailable
- On initialization, checks for `trifle_auth_token` in URL hash (set by backend redirect fallback) and completes the auth flow
- Cleans the token from the URL immediately via `replaceState`

**Companion PR:** trifle-labs/trifle-bot#167 (or next PR number — see trifle-bot `fix/twitter-inapp-browser-auth` branch)

## Context
In Twitter/X's in-app browser (WebView), `window.opener` is `null`, so `window.opener.postMessage()` silently fails. Users complete Twitter OAuth successfully but get stuck on "you can close this window now" because the token never reaches the parent page. This adds a redirect-based fallback: the backend redirects back to the frontend with the JWT in a URL hash fragment.

## Test plan
- [ ] Normal browser: Twitter auth via popup still works (postMessage path)
- [ ] Mobile browser: Twitter auth still works
- [ ] Twitter in-app browser: auth completes via redirect fallback instead of getting stuck
- [ ] Discord auth: same fix applies, test in normal + in-app browsers
- [ ] Farcaster: existing `sdk.actions.openUrl` + polling path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)