### PR TITLE
Export shared tailwind theme, TrifleBall, and button customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trifle/trifle-hub",
-  "version": "1.0.155",
+  "version": "1.0.156",
   "description": "Vue component library for Trifle Hub",
   "keywords": [
     "vue",

--- a/src/TrifleHub.vue
+++ b/src/TrifleHub.vue
@@ -5,6 +5,8 @@
     :hubPageKey="hubPageKey"
     :position="props.position"
     :avatar3d="props.avatar3d"
+    :buttonSize="props.buttonSize"
+    :buttonTarget="props.buttonTarget"
   />
 </template>
 
@@ -22,6 +24,14 @@ const props = defineProps({
   avatar3d: {
     type: Boolean,
     default: true
+  },
+  buttonSize: {
+    type: String,
+    default: undefined
+  },
+  buttonTarget: {
+    type: String,
+    default: undefined
   }
 })
 

--- a/src/components/Hub.vue
+++ b/src/components/Hub.vue
@@ -13,14 +13,11 @@
       aria-label="close hub"
     ></button>
     <!-- menu button / labels -->
+    <Teleport :to="props.buttonTarget" :disabled="!props.buttonTarget">
     <div
       id="trifle-hub__menu-button"
-      class="_fixed _z-10 trifle-hub-position focus-visible:_ring-4 _rounded-full"
-      style="
-        width: var(--thub-menu-button-size);
-        height: var(--thub-menu-button-size);
-        margin: var(--thub-menu-button-margin);
-      "
+      :class="[props.buttonTarget ? '' : '_fixed trifle-hub-position', '_z-10 focus-visible:_ring-4 _rounded-full']"
+      :style="menuButtonStyle"
       tabindex="0"
       @keydown.space="hubOpen = !hubOpen"
       @keydown.enter="hubOpen = !hubOpen"
@@ -62,6 +59,7 @@
         tabindex="-1"
       />
     </div>
+    </Teleport>
     <!-- (hub panel) -->
     <transition name="thub-fade-in-scale-up">
       <aside
@@ -230,10 +228,21 @@ const hubOpen = defineModel('hubOpen')
 const props = defineProps({
   hubPageKey: { type: String, required: true },
   position: { type: String, default: 'bottom-left', required: true },
-  avatar3d: { type: Boolean, default: true }
+  avatar3d: { type: Boolean, default: true },
+  buttonSize: { type: String, default: undefined },
+  buttonTarget: { type: String, default: undefined }
 })
 
 const hubPage = computed(() => hubPages[props.hubPageKey] || hubPages.account)
+
+const menuButtonStyle = computed(() => {
+  const size = props.buttonSize || 'var(--thub-menu-button-size)'
+  return {
+    width: size,
+    height: size,
+    margin: props.buttonTarget ? '0' : 'var(--thub-menu-button-margin)'
+  }
+})
 
 const { openHub } = inject('hub')
 const auth = inject('TrifleHub/store')

--- a/src/config/tailwindTheme.js
+++ b/src/config/tailwindTheme.js
@@ -1,0 +1,76 @@
+/**
+ * Shared Tailwind theme extensions for trifle apps.
+ * Import and spread into your tailwind.config.js theme.extend:
+ *
+ *   const { trifleTheme } = require('@trifle/trifle-hub/dist/config/tailwindTheme')
+ *   // or
+ *   import { trifleTheme } from '@trifle/trifle-hub/dist/config/tailwindTheme'
+ *
+ *   module.exports = {
+ *     theme: { extend: { ...trifleTheme, ...yourOverrides } }
+ *   }
+ */
+
+export const trifleTheme = {
+  fontFamily: {
+    trifle: ['"APL333"', '"Comic Sans MS"', 'sans-serif']
+  },
+  colors: {
+    rot: 'var(--thub-color-rot)',
+    'thub-primary': 'var(--thub-color-primary)',
+    trifle: {
+      blue: '#4100ff',
+      green: '#22c55e',
+      gold: '#f59e0b',
+      red: '#f43c34'
+    }
+  },
+  screens: {
+    xs: '440px',
+    mouse: { raw: '(hover:hover)' },
+    touch: { raw: '(hover:none)' }
+  },
+  boxShadow: {
+    px: '0 1px 1px var(--thub-shadow-color)',
+    'panel-xs': '0 0.75px 0.75px var(--thub-shadow-color), inset 0 0.75px 0 rgba(255, 255, 255, 0.75)',
+    panel: '0 1px 1px var(--thub-shadow-color), inset 0 1px 0 rgba(255, 255, 255, 0.75)',
+    'panel-inset': '0 1px 1px var(--thub-shadow-color) inset, 0 1px 0 rgba(255, 255, 255, 0.75)',
+    'panel-md': '0 1.25px 1.25px var(--thub-shadow-color), inset 0 1.25px 0 rgba(255, 255, 255, 0.75)',
+    deep: '0 4px 8px 0 rgba(0, 0, 0, 0.5)'
+  },
+  animation: {
+    'pulse-light': 'pulse-light 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+    'pulse-deep': 'pulse-deep 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+    wiggle: 'wiggle 0.8s linear infinite',
+    'wiggle-sm': 'wiggle-sm 0.8s linear infinite',
+    float: 'float 4s ease-in-out infinite',
+    'scaleup-sm': 'scaleup-sm 1s ease-in-out infinite',
+    'scaleup-xs': 'scaleup-xs 1s ease-in-out infinite'
+  },
+  keyframes: {
+    'pulse-light': { '0%, 100%': { opacity: 1 }, '50%': { opacity: 0.75 } },
+    'pulse-deep': { '0%, 100%': { opacity: 1 }, '50%': { opacity: 0.25 } },
+    'wiggle-sm': {
+      '0%, 100%': { transform: 'rotate(0deg)' },
+      '25%': { transform: 'rotate(-1.5deg)' },
+      '75%': { transform: 'rotate(1.5deg)' }
+    },
+    wiggle: {
+      '0%, 100%': { transform: 'rotate(0deg)' },
+      '25%': { transform: 'rotate(-5deg)' },
+      '75%': { transform: 'rotate(5deg)' }
+    },
+    float: {
+      '0%, 100%': { transform: 'translateY(0)' },
+      '50%': { transform: 'translateY(-4px)' }
+    },
+    'scaleup-sm': {
+      '0%, 100%': { transform: 'scale(1)' },
+      '50%': { transform: 'scale(1.05)' }
+    },
+    'scaleup-xs': {
+      '0%, 100%': { transform: 'scale(1)' },
+      '50%': { transform: 'scale(1.025)' }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,10 @@ const TrifleHubVuePlugin = {
  * TrifleHub main component
  * @type {import('vue').Component}
  */
-export { TrifleHubVuePlugin, TrifleHub, TrifleGuide, SwapBalls }
+const TrifleBall = () => import('./components/TrifleBall/TrifleBall.vue')
+
+export { TrifleHubVuePlugin, TrifleHub, TrifleGuide, SwapBalls, TrifleBall }
 export { possiblePoints } from './config/pointsConfig'
+export { trifleTheme } from './config/tailwindTheme'
 
 // export default TrifleHubVuePlugin


### PR DESCRIPTION
## Summary
- Export `trifleTheme` from `src/config/tailwindTheme.js` — shared fonts, colors, shadows, animations for consumer Tailwind configs
- Export `TrifleBall` component for standalone use outside the hub panel
- Add `buttonSize` prop to control the menu button dimensions
- Add `buttonTarget` prop to teleport the menu button to a custom DOM element (e.g. for hero sections)
- Bump version to 1.0.156

## Test plan
- [ ] Verify build succeeds (`yarn build`)
- [ ] Verify consumer apps can import `trifleTheme` and spread into their tailwind config
- [ ] Verify `buttonTarget` teleports the ball to the specified element
- [ ] Verify `buttonSize` overrides the default button size
- [ ] Verify default behavior (no new props) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)