### PR TITLE
Add Solana wallet authentication UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@reown/appkit-siwe": "^1.7.8",
     "@tanstack/vue-query": "^5.75.1",
     "@vueuse/core": "^10.0.0",
+    "@wallet-standard/core": "^1.1.1",
     "tailwindcss": "^3.4.15"
   },
   "devDependencies": {
@@ -76,14 +77,14 @@
     "vue-router": "^4.5.0"
   },
   "peerDependencies": {
-    "vue": "^3.5.13",
-    "vue-router": "^4.5.0",
-    "@wagmi/core": "^2.17.2",
-    "@wagmi/vue": "^0.1.21",
-    "viem": "^2.0.0",
     "@farcaster/miniapp-sdk": "^0.2.0",
     "@farcaster/miniapp-wagmi-connector": "^1.0.0",
+    "@wagmi/core": "^2.17.2",
+    "@wagmi/vue": "^0.1.21",
     "pinia": "^3.0.2",
-    "three": "^0.181.1"
+    "three": "^0.181.1",
+    "viem": "^2.0.0",
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.0"
   }
 }

--- a/src/assets/imgs/solana-logo.svg
+++ b/src/assets/imgs/solana-logo.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <path d="M25.5 95.5a4.3 4.3 0 0 1 3-1.3h87.2c1.9 0 2.9 2.3 1.5 3.7l-18.7 18.8a4.3 4.3 0 0 1-3 1.3H8.3c-1.9 0-2.9-2.3-1.5-3.7L25.5 95.5z" fill="url(#a)"/>
+  <path d="M25.5 11.3a4.4 4.4 0 0 1 3-1.3h87.2c1.9 0 2.9 2.3 1.5 3.7l-18.7 18.8a4.3 4.3 0 0 1-3 1.3H8.3c-1.9 0-2.9-2.3-1.5-3.7L25.5 11.3z" fill="url(#b)"/>
+  <path d="M102.5 53.2a4.3 4.3 0 0 0-3-1.3H12.3c-1.9 0-2.9 2.3-1.5 3.7l18.7 18.8a4.3 4.3 0 0 0 3 1.3h87.2c1.9 0 2.9-2.3 1.5-3.7L102.5 53.2z" fill="url(#c)"/>
+  <defs>
+    <linearGradient id="a" x1="113.3" y1="3" x2="30.3" y2="125" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00FFA3"/>
+      <stop offset="1" stop-color="#DC1FFF"/>
+    </linearGradient>
+    <linearGradient id="b" x1="82" y1="-13" x2="-1" y2="109" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00FFA3"/>
+      <stop offset="1" stop-color="#DC1FFF"/>
+    </linearGradient>
+    <linearGradient id="c" x1="97" y1="-5" x2="14" y2="117" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#00FFA3"/>
+      <stop offset="1" stop-color="#DC1FFF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/AccountSettings.vue
+++ b/src/components/AccountSettings.vue
@@ -137,6 +137,68 @@
       </ul>
     </section>
 
+    <!-- solana -->
+    <section
+      class="_bg-metallic-linear _shadow-panel _p-4 _space-y-1.5 _rounded-lg"
+      :class="{ '_order-last': !solanaAuths?.length }"
+    >
+      <div v-if="solanaAuths.length" class="_flex _items-center _gap-2.5 _-mt-1.5">
+        <h3 class="_text-mlg _opacity-30 _weight-bold">
+          solana wallet{{ solanaAuths.length > 1 ? 's' : '' }}
+        </h3>
+      </div>
+      <ul class="_flex _flex-col _gap-0.5">
+        <li
+          v-for="solana in solanaAuths"
+          :key="solana.id"
+          class="_flex _items-center _p-2 _pr-3.5 _justify-between _bg-metallic-linear _shadow-panel _rounded-lg"
+        >
+          <div class="_flex _items-center _gap-2">
+            <div class="_size-11 _flex _items-stretch _p-1.5 _rounded-md">
+              <div class="_w-full _flex _items-center _justify-center">
+                <img
+                  src="../assets/imgs/solana-logo.svg"
+                  class="_size-6 _rounded"
+                  style="background-color: #000"
+                />
+              </div>
+            </div>
+            <div class="_flex-1 _min-w-0 _leading-tight">
+              <div class="_flex-1 _min-w-0 _truncate _text-em-lg">
+                {{ truncateSolanaAddress(solana.id) }}
+              </div>
+            </div>
+          </div>
+          <!-- (disconnect solana button) -->
+          <template v-if="totalAccountConnections > 1">
+            <button
+              class="_bubble-btn _h-10 _text-sm _text-stroke-md _px-[1em]"
+              @click="(e) => handleDisconnectPlatform('solana', solana.id, e)"
+              aria-label="Remove"
+            >
+              <span>
+                <template
+                  v-if="aboutToDisconnect.platform == 'solana' && aboutToDisconnect.id == solana.id"
+                >
+                  Confirm?
+                </template>
+                <template v-else> ⛌ </template>
+              </span>
+            </button>
+          </template>
+        </li>
+        <AuthButton
+          v-if="!hasSolanaAuth"
+          platform="solana"
+          :points="!solanaAuths.length ? '+10' : undefined"
+          :disabled="auth.isSimulationMode"
+          class="_w-full"
+        >
+          {{ solanaAuths.length > 0 ? 'Link another Solana' : 'Link Solana' }}
+        </AuthButton>
+      </ul>
+    </section>
+
     <!-- discord -->
     <section
       class="_bg-metallic-linear _shadow-panel _p-4 _space-y-1.5 _rounded-lg"
@@ -543,6 +605,7 @@ const addFrame = async () => {
 }
 
 const walletAuths = computed(() => auth.getPlatformData('wallet'))
+const solanaAuths = computed(() => auth.getPlatformData('solana'))
 const discordAuths = computed(() => auth.getPlatformData('discord').filter((d) => d.username))
 const farcasterAuths = computed(() => auth.getPlatformData('farcaster'))
 const twitterAuths = computed(() => auth.getPlatformData('twitter').filter((t) => t.username))
@@ -552,10 +615,12 @@ const hasDiscordAuth = computed(() => discordAuths.value.length > 0)
 const hasFarcasterAuth = computed(() => farcasterAuths.value.length > 0)
 const hasTwitterAuth = computed(() => twitterAuths.value.length > 0)
 const hasTelegramAuth = computed(() => telegramAuths.value.length > 0)
+const hasSolanaAuth = computed(() => solanaAuths.value.length > 0)
 
 const totalAccountConnections = computed(
   () =>
     walletAuths.value.length +
+    solanaAuths.value.length +
     discordAuths.value.length +
     farcasterAuths.value.length +
     twitterAuths.value.length +
@@ -602,6 +667,11 @@ watch(aboutToDisconnect, (newValue) => {
 const truncateAddress = (address) => {
   if (!address) return ''
   return `0x${address.slice(2, 6).toUpperCase()}...${address.slice(-4).toUpperCase()}`
+}
+
+const truncateSolanaAddress = (address) => {
+  if (!address) return ''
+  return `${address.slice(0, 4)}...${address.slice(-4)}`
 }
 
 const handleLogout = async () => {

--- a/src/components/AuthButton.vue
+++ b/src/components/AuthButton.vue
@@ -118,6 +118,9 @@ const handleConnect = async (platform) => {
     case 'telegram':
       await handleTelegramConnect()
       break
+    case 'solana':
+      await handleSolanaConnect()
+      break
     default:
       throw new Error(`Unsupported platform: ${platform}`)
   }
@@ -184,6 +187,18 @@ const handleTelegramConnect = async () => {
     auth.addNotification({
       type: 'error',
       message: 'Telegram login failed. Try again?'
+    })
+  }
+}
+
+const handleSolanaConnect = async () => {
+  try {
+    await auth.connectSolana()
+  } catch (err) {
+    console.error('Solana connection failed:', err)
+    auth.addNotification({
+      type: 'error',
+      message: err.message || 'Solana login failed. Try again?'
     })
   }
 }

--- a/src/config/pointsConfig.js
+++ b/src/config/pointsConfig.js
@@ -2,6 +2,7 @@ import discordIcon from '../assets/imgs/discord-logo-90.png'
 import twitterIcon from '../assets/imgs/twitter-x-logo.svg'
 import telegramIcon from '../assets/imgs/telegram-logo.svg'
 import walletIcon from '../assets/imgs/ethereum-logo-orange-bg.svg'
+import solanaIcon from '../assets/imgs/solana-logo.svg'
 import farcasterIcon from '../assets/imgs/farcaster-logo.svg'
 import anybodyIcon from '../assets/imgs/anybody-icon.png'
 import kudzuIcon from '../assets/imgs/kudzu-icon.gif'
@@ -39,6 +40,17 @@ export const possiblePoints = [
     icon: walletIcon,
     // description: 'Authenticate with your wallet address to earn 10 pachinko balls.',
     // description: 'in the Account page',
+    pachinkoBalls: 10,
+    kudzuBurn: 0,
+    claimed: false,
+    once: true,
+    enabled: true,
+    link: { to: 'account' }
+  },
+  {
+    name: 'Link Solana Wallet',
+    id: 'auth-solana',
+    icon: solanaIcon,
     pachinkoBalls: 10,
     kudzuBurn: 0,
     claimed: false,

--- a/src/config/socialsConfig.js
+++ b/src/config/socialsConfig.js
@@ -1,4 +1,5 @@
 import ethereumLogo from '../assets/imgs/ethereum-logo-white.svg'
+import solanaLogo from '../assets/imgs/solana-logo.svg'
 import discordLogo from '../assets/imgs/discord-logo.svg'
 import farcasterLogo from '../assets/imgs/farcaster-logo.svg'
 import twitterLogo from '../assets/imgs/twitter-x-logo.svg'
@@ -13,6 +14,15 @@ export const platforms = {
       hueRotate: -236,
       saturate: 1.5
     }
+  },
+  solana: {
+    name: 'Solana',
+    icon: solanaLogo,
+    bubbleButtonStyle: {
+      hueRotate: -280,
+      saturate: 1.5
+    },
+    textColor: '#9945FF'
   },
   discord: {
     name: 'Discord',

--- a/src/store.js
+++ b/src/store.js
@@ -12,10 +12,12 @@ import { mainnet, base } from '@reown/appkit/networks'
 
 import { createSiweMessage } from 'viem/siwe'
 import { sdk } from '@farcaster/miniapp-sdk'
+import { getWallets } from '@wallet-standard/core'
 
 // Platform types
 const PLATFORMS = {
   WALLET: 'wallet',
+  SOLANA: 'solana',
   TELEGRAM: 'telegram',
   DISCORD: 'discord',
   FARCASTER: 'farcaster',
@@ -1067,6 +1069,190 @@ export const useAuthStore = defineStore('auth', {
       } finally {
         this.authSteps.wallet.signing = false
         this.authSteps.wallet.verifying = false
+      }
+    },
+
+    _getSolanaWallet() {
+      // Try Wallet Standard first (MetaMask, Phantom, Solflare, etc.)
+      try {
+        const { get } = getWallets()
+        const wallets = get()
+        const solanaWallet = wallets.find(
+          (w) =>
+            w.chains?.some((c) => c.startsWith('solana:')) &&
+            w.features?.['solana:signMessage']
+        )
+        if (solanaWallet) return { type: 'standard', wallet: solanaWallet }
+      } catch (e) {
+        console.warn('Wallet Standard not available:', e)
+      }
+
+      // Fallback to legacy window.solana (older Phantom versions)
+      const legacy = window.solana || window.phantom?.solana
+      if (legacy) return { type: 'legacy', wallet: legacy }
+
+      return null
+    },
+
+    async connectSolana() {
+      try {
+        this.loading = true
+
+        const walletInfo = this._getSolanaWallet()
+        if (!walletInfo) {
+          throw new Error('No Solana wallet found. Please install Phantom, MetaMask, or another Solana wallet.')
+        }
+
+        let publicKey
+        let provider
+
+        if (walletInfo.type === 'standard') {
+          const wallet = walletInfo.wallet
+          // Connect if the wallet supports it
+          if (wallet.features?.['standard:connect']) {
+            await wallet.features['standard:connect'].connect()
+          }
+          // Get first Solana account
+          const solanaAccount = wallet.accounts.find((a) =>
+            a.chains?.some((c) => c.startsWith('solana:'))
+          )
+          if (!solanaAccount) {
+            throw new Error('No Solana account found in wallet. Please add a Solana account.')
+          }
+          publicKey = solanaAccount.address
+          provider = { _standard: wallet, _account: solanaAccount }
+        } else {
+          // Legacy provider
+          provider = walletInfo.wallet
+          const resp = await provider.connect()
+          publicKey = resp.publicKey.toString()
+        }
+
+        // Authenticate with the backend
+        await this.authenticateWithSolana(publicKey, provider)
+        return true
+      } catch (error) {
+        console.error('Solana connection error:', error)
+        throw error
+      } finally {
+        this.loading = false
+      }
+    },
+
+    async authenticateWithSolana(publicKey, provider) {
+      try {
+        const headers = {
+          'Content-Type': 'application/json'
+        }
+        if (this.isAuthenticated) {
+          headers.Authorization = `Bearer ${this.authToken}`
+        }
+
+        // 1. Get nonce from server
+        const nonceResponse = await fetch(`${this.backendUrl}/auth/solana/nonce`, {
+          method: 'POST',
+          headers
+        })
+        if (!nonceResponse.ok) {
+          throw new Error('Failed to get nonce')
+        }
+        const { nonce } = await nonceResponse.json()
+
+        // 2. Build SIWS-style message
+        const domain = window.location.host
+        const uri = window.location.origin
+        const issuedAt = new Date().toISOString()
+        const statement = 'Sign this message to prove you own this wallet (at no cost to you).'
+
+        const header = { t: 'sip99' }
+        const payload = {
+          domain,
+          address: publicKey,
+          statement,
+          uri,
+          version: '1',
+          chainId: 1,
+          nonce,
+          issuedAt
+        }
+
+        // Build the plaintext message matching SIWS format (must match server's SIWS.prepareMessage())
+        const message = [
+          `${domain} wants you to sign in with your Solana account:`,
+          publicKey,
+          '',
+          `${statement}`,
+          '',
+          `URI: ${uri}`,
+          `Version: 1`,
+          `Chain ID: 1`,
+          `Nonce: ${nonce}`,
+          `Issued At: ${issuedAt}`
+        ].join('\n')
+
+        // 3. Sign the message
+        const encodedMessage = new TextEncoder().encode(message)
+        let sigBytes
+
+        if (provider._standard) {
+          // Wallet Standard provider (MetaMask, modern Phantom, etc.)
+          const [result] = await provider._standard.features['solana:signMessage'].signMessage({
+            account: provider._account,
+            message: encodedMessage
+          })
+          sigBytes = result.signature
+        } else {
+          // Legacy provider (older Phantom)
+          const signedMessage = await provider.signMessage(encodedMessage, 'utf8')
+          sigBytes = signedMessage.signature
+        }
+
+        // Encode signature as base58 (required by @web3auth/sign-in-with-solana verify)
+        const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+        const toBase58 = (bytes) => {
+          let num = BigInt('0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join(''))
+          let result = ''
+          while (num > 0n) {
+            result = BASE58_ALPHABET[Number(num % 58n)] + result
+            num = num / 58n
+          }
+          for (const b of bytes) {
+            if (b === 0) result = '1' + result
+            else break
+          }
+          return result || '1'
+        }
+        const signature = {
+          t: 'sip99',
+          s: toBase58(sigBytes)
+        }
+
+        // 4. Verify signature and get token
+        const verifyUrl = `${this.backendUrl}/auth/solana/${
+          this.isAuthenticated ? 'add-verify' : 'verify'
+        }`
+        const verifyResponse = await fetch(verifyUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            header,
+            payload,
+            signature
+          })
+        })
+        if (!verifyResponse.ok) {
+          throw new Error('Failed to verify signature')
+        }
+        const verifyResult = await verifyResponse.json()
+        if (verifyResult.token) {
+          this.setAuthToken(verifyResult.token)
+        }
+
+        await this.fetchUserStatus()
+        return true
+      } catch (error) {
+        console.error('Solana authentication error:', error)
+        throw error
       }
     },
 

--- a/src/views/Account/ConnectAccount.vue
+++ b/src/views/Account/ConnectAccount.vue
@@ -35,6 +35,7 @@
         <template v-else>
           <AuthButton platform="wallet" points="+10"> Wallet Login </AuthButton>
         </template>
+        <AuthButton platform="solana" points="+10"> Solana Login </AuthButton>
         <AuthButton platform="discord" points="+10"> Discord Login </AuthButton>
         <AuthButton platform="twitter" points="+10"> TwitterX Login </AuthButton>
         <AuthButton platform="telegram" points="+10"> Telegram Login </AuthButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,12 +2416,45 @@
     "@wagmi/connectors" "5.9.4"
     "@wagmi/core" "2.19.0"
 
+"@wallet-standard/app@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/app/-/app-1.1.0.tgz#2ca32e4675536224ebe55a00ad533b7923d7380a"
+  integrity sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==
+  dependencies:
+    "@wallet-standard/base" "^1.1.0"
+
 "@wallet-standard/base@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@wallet-standard/base/-/base-1.1.0.tgz#214093c0597a1e724ee6dbacd84191dfec62bb33"
   integrity sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==
 
-"@wallet-standard/wallet@1.1.0":
+"@wallet-standard/core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/core/-/core-1.1.1.tgz#432e10420dc8892a63224d4863f8304fa01b4ea1"
+  integrity sha512-5Xmjc6+Oe0hcPfVc5n8F77NVLwx1JVAoCVgQpLyv/43/bhtIif+Gx3WUrDlaSDoM8i2kA2xd6YoFbHCxs+e0zA==
+  dependencies:
+    "@wallet-standard/app" "^1.1.0"
+    "@wallet-standard/base" "^1.1.0"
+    "@wallet-standard/errors" "^0.1.1"
+    "@wallet-standard/features" "^1.1.0"
+    "@wallet-standard/wallet" "^1.1.0"
+
+"@wallet-standard/errors@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/errors/-/errors-0.1.1.tgz#e745c5925276c0ac6d02f0d489888c171f5e4680"
+  integrity sha512-V8Ju1Wvol8i/VDyQOHhjhxmMVwmKiwyxUZBnHhtiPZJTWY0U/Shb2iEWyGngYEbAkp2sGTmEeNX1tVyGR7PqNw==
+  dependencies:
+    chalk "^5.4.1"
+    commander "^13.1.0"
+
+"@wallet-standard/features@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/features/-/features-1.1.0.tgz#f256d7b18940c8d134f66164330db358a8f5200e"
+  integrity sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==
+  dependencies:
+    "@wallet-standard/base" "^1.1.0"
+
+"@wallet-standard/wallet@1.1.0", "@wallet-standard/wallet@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@wallet-standard/wallet/-/wallet-1.1.0.tgz#a1e46a3f1b2d06a0206058562169b1f0e9652d0f"
   integrity sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==
@@ -3371,6 +3404,11 @@ commander@14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.0.tgz#f244fc74a92343514e56229f16ef5c5e22ced5e9"
   integrity sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==
+
+commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
 
 commander@^14.0.0:
   version "14.0.2"


### PR DESCRIPTION
## Summary
- Add Solana login button to connect page and account settings for logged-in users
- Use Wallet Standard API (`@wallet-standard/core`) to detect MetaMask, Phantom, Solflare, and other Solana wallets, with legacy `window.solana` fallback
- Build and sign SIWS-formatted messages, encode signatures as base58
- Add Solana platform config (icon, button style), quest entry (`auth-solana`, +10 balls), and linked wallet management with disconnect support

**Depends on:** trifle-labs/trifle-bot#(solana-wallet-auth PR) for backend endpoints

## Test plan
- [ ] Click "Solana Login" with MetaMask (Solana enabled) — should detect wallet via Wallet Standard
- [ ] Click "Solana Login" with Phantom — should detect via Wallet Standard or legacy provider
- [ ] Complete sign-in flow — should authenticate and show Solana wallet in account settings
- [ ] Verify +10 balls awarded for first Solana auth
- [ ] Test "Link Solana" from account settings when already logged in with another method
- [ ] Test disconnect Solana wallet from account settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)