### PR TITLE
feat: show airdrop events in profile activity (v1.0.164)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trifle/trifle-hub",
-  "version": "1.0.163",
+  "version": "1.0.164",
   "description": "Vue component library for Trifle Hub",
   "keywords": [
     "vue",

--- a/src/config/pointsConfig.js
+++ b/src/config/pointsConfig.js
@@ -10,6 +10,7 @@ import gmIcon from '../assets/imgs/gm.svg'
 import snakeIcon from '../assets/imgs/snake-hub-icon.png'
 import lotteryIcon from '../assets/imgs/lottery-icon.png'
 import tiltLottoHead from '../assets/imgs/tilt-lotto-head-3.png'
+import airdropIcon from '../assets/imgs/disco-ball-emoji.png'
 import { platforms } from './socialsConfig'
 // import { sdk } from '@farcaster/miniapp-sdk'
 
@@ -151,6 +152,13 @@ export const possiblePoints = [
     icon: snakeIcon,
     hiddenFromQuests: true,
     link: snakeLink
+  },
+  {
+    name: 'Airdrop',
+    id: 'airdrop',
+    icon: airdropIcon,
+    activityText: 'Received an airdrop',
+    hiddenFromQuests: true
   },
   {
     name: 'Snake Tutorial',


### PR DESCRIPTION
## What

Adds the `airdrop` point type to `pointsConfig` (disco-ball icon 🪩, "Received an airdrop") so admin airdrops from trifle-bot render properly in the profile activity feed. Hidden from the quests list (`hiddenFromQuests`), shown in activity only.

Bumps version **1.0.163 → 1.0.164** for release.

## Companion

Backend endpoint: trifle-labs/trifle-bot#419. The activity feed reads from trifle-bot's `/balls/list`, so airdrops appear regardless; this PR just gives them an icon + friendly label instead of the raw `airdrop` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
