### PR TITLE
fix: release WebGL context on TrifleBall teardown

### DIFF
--- a/src/components/TrifleBall/trifle-ball.js
+++ b/src/components/TrifleBall/trifle-ball.js
@@ -640,6 +640,9 @@ export class BallVisualizer {
 
     if (this.renderer) {
       this.renderer.dispose()
+      this.renderer.forceContextLoss() // dispose() frees GPU caches but not the GL context; this releases it
+      this.renderer.domElement?.remove() // detach the canvas Three appended in init()
+      this.renderer = null // drop the ref so the canvas/context can be GC'd
     }
   }
 


### PR DESCRIPTION
## Why
`renderer.dispose()` frees Three's GPU caches but does **not** release the underlying WebGL context — the context lingers until the canvas is GC'd. Because `Profile.vue` keys `<TrifleBall :key="displayAvatar">`, every avatar change fully unmounts/remounts the component and leaks another context. Past the browser's per-page cap (~16), the oldest live context gets evicted — which is what blanks out the ball when other WebGL surfaces (e.g. the snake Three.js overlay on the same page) push the count over.

## What
In `trifle-ball.js` `cleanup()`:
- `renderer.forceContextLoss()` — actually releases the GL context
- `renderer.domElement?.remove()` — detach the canvas Three appended in `init()`
- null the ref so the canvas/context can be GC'd

Three owns this canvas (it called `container.appendChild(renderer.domElement)`), so it must detach it on teardown.

## Test plan
- Open a consumer page with TrifleBall mounted; in DevTools Performance/Memory, confirm no "Too many active WebGL contexts" warning across repeated mount/unmount cycles (Profile avatar changes are the easiest repro).
- Verify the ball still renders, resizes, and reacts to interaction as before — no behavior change.

## Scope
Three additive lines in one cleanup path. No API or render changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)