### PR TITLE
Fix/clamp tw v3 in layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,44 @@ trifle-hub ships its own element reset (preflight) inside `@layer trifle-hub.bas
 
 For trifle-hub's utility classes (e.g. `_bg-metallic-linear`, `_shadow-panel`) to correctly override element resets on tags like `<button>`, `trifle-hub` must be declared **after** `base` in the layer order. This ensures trifle-hub utility classes beat preflight resets, while your own app utilities still win over trifle-hub when they conflict.
 
+#### Why `index.html` — not your CSS file
+
+trifle-hub injects its CSS via JavaScript at runtime. Because CSS layer order is locked by the **first** appearance of each layer name, any `@layer` declaration in your app's CSS file may arrive too late if trifle-hub's JS runs first (which depends on import order in `main.js`).
+
+The safest approach for any Vite app is to declare the layer order as a `<style>` tag in `index.html`. It is processed by the browser before any JavaScript runs, so trifle-hub's injection always lands in the correct position.
+
+```html
+<!-- index.html <head> — before any <script> tags -->
+<style>@layer theme, base, trifle-hub, components, utilities;</style>
+```
+
+Include `theme` if you use Tailwind v4 (it has an extra `@layer properties, theme, ...` that v3 does not).
+
 #### Tailwind v4
 
-Declare the layer order before your Tailwind import. Include `base` explicitly so `trifle-hub` lands above it:
+In `index.html`:
+
+```html
+<style>@layer properties, theme, base, trifle-hub, components, utilities;</style>
+```
+
+Your `style.css` needs no extra layer declaration:
 
 ```css
-@layer base, trifle-hub, components, utilities;
 @import "tailwindcss";
 ```
 
 #### Tailwind v3 — with your own preflight
 
-Tailwind v3 outputs **unlayered** CSS by default, which unconditionally beats any `@layer` rule. To opt in to the layer system, wrap each directive in an explicit `@layer` block:
+In `index.html`:
+
+```html
+<style>@layer base, trifle-hub, components, utilities;</style>
+```
+
+Tailwind v3 outputs **unlayered** CSS by default, which unconditionally beats any `@layer` rule. To opt in to the layer system, wrap each directive in an explicit `@layer` block in your CSS:
 
 ```css
-@layer base, trifle-hub, components, utilities;
-
 @layer base {
   @tailwind base;
 }
@@ -112,11 +134,15 @@ Any styles written outside a `@layer` block remain unlayered and beat everything
 
 #### Tailwind v3 — without your own preflight
 
-If your app has `/* @tailwind base; */` commented out (relying on trifle-hub's built-in reset), just declare the `trifle-hub` layer. Your unlayered `@tailwind components/utilities` output naturally beats `@layer trifle-hub` without needing any wrapping:
+In `index.html`:
+
+```html
+<style>@layer trifle-hub;</style>
+```
+
+If your app has `@tailwind base` commented out (relying on trifle-hub's built-in reset), your unlayered `@tailwind components/utilities` output naturally beats `@layer trifle-hub` without needing any wrapping:
 
 ```css
-@layer trifle-hub;
-
 /* @tailwind base; */   ← leave commented out
 @tailwind components;
 @tailwind utilities;

--- a/README.md
+++ b/README.md
@@ -73,34 +73,58 @@ Add the TrifleHub component to your app layout:
 
 CSS is automatically injected when the plugin is registered — no separate stylesheet import is required.
 
-Since v1.1.0, all compiled styles ship inside `@layer trifle-hub`. This means:
+Since v1.1.0, all compiled styles ship inside `@layer trifle-hub`. This keeps trifle-hub's styles from polluting the global cascade and lets you control where they sit relative to your own CSS.
 
-- **Tailwind v4 apps**: trifle-hub styles fall below your app's utilities in the default layer order, so your own classes always win.
-- **Tailwind v3 apps**: behavior is unchanged — unlayered app CSS still takes precedence over layered library styles.
-- **No Tailwind**: styles work as before; the `@layer` block is ignored by browsers that don't use cascade layers.
+trifle-hub ships its own element reset (preflight) inside `@layer trifle-hub.base`. If your app has no preflight of its own, trifle-hub provides the baseline for buttons, inputs, etc.
 
-### Controlling layer order
+### Layer order
 
-If you need trifle-hub styles to appear at a specific position in your cascade (e.g., between base and your components), declare the order explicitly before your first import:
+For trifle-hub's utility classes (e.g. `_bg-metallic-linear`, `_shadow-panel`) to correctly override element resets on tags like `<button>`, `trifle-hub` must be declared **after** `base` in the layer order. This ensures trifle-hub utility classes beat preflight resets, while your own app utilities still win over trifle-hub when they conflict.
+
+#### Tailwind v4
+
+Declare the layer order before your Tailwind import. Include `base` explicitly so `trifle-hub` lands above it:
 
 ```css
-/* Tailwind v4 */
-@layer trifle-hub, components, utilities;
+@layer base, trifle-hub, components, utilities;
 @import "tailwindcss";
-@import "@trifle/trifle-hub/dist/trifle-hub.css";
 ```
+
+#### Tailwind v3 — with your own preflight
+
+Tailwind v3 outputs **unlayered** CSS by default, which unconditionally beats any `@layer` rule. To opt in to the layer system, wrap each directive in an explicit `@layer` block:
 
 ```css
-/* Tailwind v3 */
-@layer trifle-hub, components, utilities;
-@import "@trifle/trifle-hub/dist/trifle-hub.css";
+@layer base, trifle-hub, components, utilities;
+
+@layer base {
+  @tailwind base;
+}
+@layer components {
+  @tailwind components;
+}
+@layer utilities {
+  @tailwind utilities;
+}
 ```
 
-When importing the standalone CSS file directly, the CSS auto-injection from the JS bundle is still active. To avoid loading styles twice, either remove the direct import or disable CSS injection from the JS side.
+Any styles written outside a `@layer` block remain unlayered and beat everything above.
+
+#### Tailwind v3 — without your own preflight
+
+If your app has `/* @tailwind base; */` commented out (relying on trifle-hub's built-in reset), just declare the `trifle-hub` layer. Your unlayered `@tailwind components/utilities` output naturally beats `@layer trifle-hub` without needing any wrapping:
+
+```css
+@layer trifle-hub;
+
+/* @tailwind base; */   ← leave commented out
+@tailwind components;
+@tailwind utilities;
+```
 
 ### Standalone CSS file
 
-The compiled stylesheet is available at `dist/trifle-hub.css` if you prefer to manage it explicitly (e.g., for SSR, critical CSS extraction, or strict layer ordering). The `style` field in the package manifest points to this file.
+The compiled stylesheet is available at `dist/trifle-hub.css` if you prefer to manage it explicitly (e.g., for SSR, critical CSS extraction, or strict layer ordering). The `style` field in the package manifest points to this file. If importing it directly, note that the JS bundle also auto-injects the CSS — disable one or the other to avoid loading styles twice.
 
 ## Available Provide/Inject Resources
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,39 @@ Add the TrifleHub component to your app layout:
 </script>
 ```
 
+## Styles
+
+CSS is automatically injected when the plugin is registered — no separate stylesheet import is required.
+
+Since v1.1.0, all compiled styles ship inside `@layer trifle-hub`. This means:
+
+- **Tailwind v4 apps**: trifle-hub styles fall below your app's utilities in the default layer order, so your own classes always win.
+- **Tailwind v3 apps**: behavior is unchanged — unlayered app CSS still takes precedence over layered library styles.
+- **No Tailwind**: styles work as before; the `@layer` block is ignored by browsers that don't use cascade layers.
+
+### Controlling layer order
+
+If you need trifle-hub styles to appear at a specific position in your cascade (e.g., between base and your components), declare the order explicitly before your first import:
+
+```css
+/* Tailwind v4 */
+@layer trifle-hub, components, utilities;
+@import "tailwindcss";
+@import "@trifle/trifle-hub/dist/trifle-hub.css";
+```
+
+```css
+/* Tailwind v3 */
+@layer trifle-hub, components, utilities;
+@import "@trifle/trifle-hub/dist/trifle-hub.css";
+```
+
+When importing the standalone CSS file directly, the CSS auto-injection from the JS bundle is still active. To avoid loading styles twice, either remove the direct import or disable CSS injection from the JS side.
+
+### Standalone CSS file
+
+The compiled stylesheet is available at `dist/trifle-hub.css` if you prefer to manage it explicitly (e.g., for SSR, critical CSS extraction, or strict layer ordering). The `style` field in the package manifest points to this file.
+
 ## Available Provide/Inject Resources
 
 The TrifleHub plugin provides several resources via Vue's provide/inject system:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trifle/trifle-hub",
-  "version": "1.0.163",
+  "version": "1.1.0",
   "description": "Vue component library for Trifle Hub",
   "keywords": [
     "vue",
@@ -34,7 +34,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/build-css.js",
     "dev": "cd dev && vite",
     "watch": "vite build --watch",
     "prepare": "[ -f dist/index.es.js ] || yarn build",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,33 @@
-export default {
-  plugins: {
-    'tailwindcss/nesting': {},
-    tailwindcss: {},
-    autoprefixer: {}
+import tailwindcssNesting from 'tailwindcss/nesting/index.js'
+import tailwindcss from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
+
+// Wraps all compiled CSS in @layer trifle-hub, keeping @font-face outside the layer.
+// This lets consumers (Tailwind v3 or v4) control cascade order without special import syntax.
+const wrapInTrifleLayer = (opts = {}) => ({
+  postcssPlugin: 'wrap-in-trifle-layer',
+  Once(root, { postcss }) {
+    const fontFaces = []
+    root.walkAtRules('font-face', rule => {
+      fontFaces.push(rule.clone())
+      rule.remove()
+    })
+    const layer = postcss.atRule({ name: 'layer', params: 'trifle-hub' })
+    ;[...root.nodes].forEach(node => {
+      node.remove()
+      layer.append(node)
+    })
+    fontFaces.forEach(ff => root.append(ff))
+    root.append(layer)
   }
+})
+wrapInTrifleLayer.postcss = true
+
+export default {
+  plugins: [
+    tailwindcssNesting,
+    tailwindcss,
+    autoprefixer,
+    wrapInTrifleLayer
+  ]
 }

--- a/scripts/build-css.js
+++ b/scripts/build-css.js
@@ -1,0 +1,42 @@
+import postcss from 'postcss'
+import tailwindcssNesting from 'tailwindcss/nesting/index.js'
+import tailwindcss from 'tailwindcss'
+import autoprefixer from 'autoprefixer'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+
+// Inline @imports manually so postcss sees the full CSS without needing postcss-import
+const fontsCSS = readFileSync('src/style/fonts.css', 'utf8')
+const resetCSS = readFileSync('src/style/reset.css', 'utf8')
+const mainCSS = readFileSync('src/style/index.css', 'utf8')
+const inlined = mainCSS
+  .replace("@import 'fonts.css';", fontsCSS)
+  .replace("@import 'reset.css';", resetCSS)
+
+const wrapInTrifleLayer = {
+  postcssPlugin: 'wrap-in-trifle-layer',
+  Once(root, { postcss: p }) {
+    const fontFaces = []
+    root.walkAtRules('font-face', rule => {
+      fontFaces.push(rule.clone())
+      rule.remove()
+    })
+    const layer = p.atRule({ name: 'layer', params: 'trifle-hub' })
+    ;[...root.nodes].forEach(node => {
+      node.remove()
+      layer.append(node)
+    })
+    fontFaces.forEach(ff => root.append(ff))
+    root.append(layer)
+  }
+}
+
+const result = await postcss([
+  tailwindcssNesting,
+  tailwindcss,
+  autoprefixer,
+  wrapInTrifleLayer
+]).process(inlined, { from: 'src/style/index.css', to: 'dist/trifle-hub.css' })
+
+mkdirSync('dist', { recursive: true })
+writeFileSync('dist/trifle-hub.css', result.css)
+console.log('Built dist/trifle-hub.css')

--- a/src/style/index.css
+++ b/src/style/index.css
@@ -1,15 +1,11 @@
-/* fonts should not be loaded in a layer! */
 @import 'fonts.css';
 @import 'reset.css';
 
-/* other styles in a layer so you can order them in consumer app no matter when they're loaded */
-/* i.e with `@layer trifle-hub, app` */
-@layer trifle-hub {
-  @tailwind base;
-  @tailwind components;
-  @tailwind utilities;
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
-  :root {
+:root {
     --thub-color-blue: #4100ff;
     --thub-color-rot: #f43c34;
 
@@ -238,4 +234,3 @@
       border-image-width: 19px;
     }
   }
-}

--- a/src/style/reset.css
+++ b/src/style/reset.css
@@ -1,4 +1,3 @@
-@layer trifle-hub {
 button {
   font-size: inherit;
   text-transform: inherit;
@@ -36,4 +35,3 @@ input::-webkit-inner-spin-button {
 input[type='number'] {
     -moz-appearance: textfield;
   }
-}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ const emSizing = {
 }
 export default {
   prefix: '_',
+  corePlugins: { preflight: false },
   content: [
     // for vite build
     './src/**/*.{vue,js,ts,jsx,tsx}',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,7 +16,6 @@ const emSizing = {
 }
 export default {
   prefix: '_',
-  corePlugins: { preflight: false },
   content: [
     // for vite build
     './src/**/*.{vue,js,ts,jsx,tsx}',


### PR DESCRIPTION
all trifle-hub css get's built inside @layer trifle-hub {} 

so consumer apps can better manage layering css rules